### PR TITLE
fixed typo in bench.js

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -2,7 +2,7 @@ var union = require('./');
 var Benchmark = require('benchmark');
 var fs = require('fs');
 
-var fcs = JSON.parse(fs.readFileSync(__dirname+'/test/fixtures/in/Intersect1.json'));
+var fcs = JSON.parse(fs.readFileSync(__dirname+'/test/fixtures/in/Intersect1.geojson'));
 
 var suite = new Benchmark.Suite('turf-union');
 suite
@@ -13,6 +13,6 @@ suite
     console.log(String(event.target));
   })
   .on('complete', function () {
-    
+
   })
   .run();


### PR DESCRIPTION
Bench was failing because the file type was wrong.